### PR TITLE
Add support for bullmq 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save @jenniferplusplus/opentelemetry-instrumentation-bullmq
 
 ### Supported Versions
 
-- `[1.90.1, 2.x]`
+- `[1.90.1, 2.x, 3.x]`
 
 It's likely that the instrumentation would support earlier versions of BullMQ, but I haven't tested it.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/semantic-conventions": "^1.6.0",
-        "bullmq": "2.*",
         "flat": "^5.0.2"
       },
       "devDependencies": {
@@ -27,6 +26,7 @@
         "@types/sinon": "^10.0.13",
         "@typescript-eslint/eslint-plugin": "^5.35.1",
         "@typescript-eslint/parser": "^5.35.1",
+        "bullmq": "^3.5.1",
         "eslint": "^8.23.0",
         "ioredis-mock": "^8.2.2",
         "mocha": "^10.0.0",
@@ -36,6 +36,9 @@
         "sinon": "^14.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.2"
+      },
+      "peerDependencies": {
+        "bullmq": "^1.90.1 || ^2 || ^3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -565,7 +568,8 @@
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -646,6 +650,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -658,6 +663,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -670,6 +676,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -682,6 +689,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -694,6 +702,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -706,6 +715,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1428,7 +1438,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1664,9 +1675,10 @@
       "dev": true
     },
     "node_modules/bullmq": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-2.4.0.tgz",
-      "integrity": "sha512-wchNwRagCfRjEqxpALD2P8Pjz110/lFnXjs/vBLWsHP5aYqyicl3EKDkrzEythZC+IEdyeaZ5wtmcSHWOAr7Sg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-3.5.1.tgz",
+      "integrity": "sha512-QxQnSIPBmEVq/bM1wxmMdh9RS4oNyUNeCvoTegr2EgtlNYToCkLgHAkM56JhaRlffo9ExNiWfVFJpXLWDfK0Fw==",
+      "dev": true,
       "dependencies": {
         "cron-parser": "^4.6.0",
         "glob": "^8.0.3",
@@ -1682,6 +1694,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1690,6 +1703,7 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
       "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1708,6 +1722,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
       "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1718,12 +1733,14 @@
     "node_modules/bullmq/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/bullmq/node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1854,6 +1871,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
       "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1982,6 +2000,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.6.0.tgz",
       "integrity": "sha512-guZNLMGUgg6z4+eGhmHGw7ft+v6OQeuHzd1gcLxCo9Yg/qoxmG3nindp2/uwGCLizEisf2H0ptqeVXeoCpP6FA==",
+      "dev": true,
       "dependencies": {
         "luxon": "^3.0.1"
       },
@@ -2075,6 +2094,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2703,7 +2723,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -3032,6 +3053,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3040,12 +3062,14 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ioredis": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.3.tgz",
       "integrity": "sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==",
+      "dev": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
@@ -3397,7 +3421,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -3408,7 +3433,8 @@
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -3425,7 +3451,8 @@
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3489,6 +3516,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.2.tgz",
       "integrity": "sha512-pfgTG/TMWzVKZ2XC4RBq3jNcidG3wxUt7ztC98Vpo5qy16uUhZrRPx8/AfVfX3LCj6I2YFSpY+vaVVVgWaDkXA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -3831,6 +3859,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.2.tgz",
       "integrity": "sha512-bqSQ0DYJbXbrJcrZFmMygUZmqQiDfI2ewFVWcrZY12w5XHWtPuW4WppDT/e63Uu311ajwkRRXSoF0uILroBeTA==",
+      "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^2.0.2"
       }
@@ -3839,6 +3868,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
       "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -3891,6 +3921,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
       "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "dev": true,
       "optional": true,
       "bin": {
         "node-gyp-build-optional-packages": "bin.js",
@@ -4025,6 +4056,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4450,6 +4482,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4458,6 +4491,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -4776,7 +4810,8 @@
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "dev": true
     },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
@@ -5266,7 +5301,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -5839,7 +5875,8 @@
     "@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "dev": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -5902,36 +5939,42 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
       "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
+      "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-darwin-x64": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz",
       "integrity": "sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==",
+      "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz",
       "integrity": "sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==",
+      "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm64": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz",
       "integrity": "sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==",
+      "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-x64": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz",
       "integrity": "sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==",
+      "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-win32-x64": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz",
       "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
+      "dev": true,
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -6458,7 +6501,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -6645,9 +6689,10 @@
       "dev": true
     },
     "bullmq": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-2.4.0.tgz",
-      "integrity": "sha512-wchNwRagCfRjEqxpALD2P8Pjz110/lFnXjs/vBLWsHP5aYqyicl3EKDkrzEythZC+IEdyeaZ5wtmcSHWOAr7Sg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-3.5.1.tgz",
+      "integrity": "sha512-QxQnSIPBmEVq/bM1wxmMdh9RS4oNyUNeCvoTegr2EgtlNYToCkLgHAkM56JhaRlffo9ExNiWfVFJpXLWDfK0Fw==",
+      "dev": true,
       "requires": {
         "cron-parser": "^4.6.0",
         "glob": "^8.0.3",
@@ -6663,6 +6708,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -6671,6 +6717,7 @@
           "version": "8.0.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
           "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6683,6 +6730,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
           "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -6690,12 +6738,14 @@
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         },
         "uuid": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+          "dev": true
         }
       }
     },
@@ -6785,7 +6835,8 @@
     "cluster-key-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
-      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "dev": true
     },
     "color-convert": {
       "version": "2.0.1",
@@ -6908,6 +6959,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.6.0.tgz",
       "integrity": "sha512-guZNLMGUgg6z4+eGhmHGw7ft+v6OQeuHzd1gcLxCo9Yg/qoxmG3nindp2/uwGCLizEisf2H0ptqeVXeoCpP6FA==",
+      "dev": true,
       "requires": {
         "luxon": "^3.0.1"
       }
@@ -6974,7 +7026,8 @@
     "denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.1",
@@ -7451,7 +7504,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -7683,6 +7737,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7691,12 +7746,14 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ioredis": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.3.tgz",
       "integrity": "sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==",
+      "dev": true,
       "requires": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
@@ -7956,7 +8013,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -7967,7 +8025,8 @@
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -7984,7 +8043,8 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -8038,7 +8098,8 @@
     "luxon": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.2.tgz",
-      "integrity": "sha512-pfgTG/TMWzVKZ2XC4RBq3jNcidG3wxUt7ztC98Vpo5qy16uUhZrRPx8/AfVfX3LCj6I2YFSpY+vaVVVgWaDkXA=="
+      "integrity": "sha512-pfgTG/TMWzVKZ2XC4RBq3jNcidG3wxUt7ztC98Vpo5qy16uUhZrRPx8/AfVfX3LCj6I2YFSpY+vaVVVgWaDkXA==",
+      "dev": true
     },
     "make-dir": {
       "version": "3.1.0",
@@ -8305,6 +8366,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.2.tgz",
       "integrity": "sha512-bqSQ0DYJbXbrJcrZFmMygUZmqQiDfI2ewFVWcrZY12w5XHWtPuW4WppDT/e63Uu311ajwkRRXSoF0uILroBeTA==",
+      "dev": true,
       "requires": {
         "msgpackr-extract": "^2.0.2"
       }
@@ -8313,6 +8375,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
       "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "dev": true,
       "optional": true,
       "requires": {
         "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
@@ -8353,6 +8416,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
       "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "dev": true,
       "optional": true
     },
     "node-libs-browser": {
@@ -8468,6 +8532,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -8802,12 +8867,14 @@
     "redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true
     },
     "redis-parser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
       "requires": {
         "redis-errors": "^1.0.0"
       }
@@ -9047,7 +9114,8 @@
     "standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "dev": true
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -9411,7 +9479,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/semantic-conventions": "^1.6.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.8.0",
         "flat": "^5.0.2"
       },
       "devDependencies": {
-        "@opentelemetry/context-async-hooks": "^1.6.0",
-        "@opentelemetry/sdk-trace-base": "^1.6.0",
-        "@opentelemetry/sdk-trace-node": "^1.6.0",
+        "@opentelemetry/context-async-hooks": "^1.8.0",
+        "@opentelemetry/sdk-trace-base": "^1.8.0",
+        "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/flat": "^5.0.2",
         "@types/ioredis": "^4.28.10",
         "@types/mocha": "^9.1.1",
@@ -757,57 +757,45 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
-      "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.6.0.tgz",
-      "integrity": "sha512-7xpyfHfuHnuCm5eAk4j4MIZjRM/hsiLlKEFIwI8SXNlbxqmb/JRrntOjN/AT+KeihkMw+xAx+0lsYPUANCSaQw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
+      "integrity": "sha512-ueLmocbWDi1aoU4IPdOQyt4qz/Dx+NYyU4qoa3d683usbnkDLUXYXJFfKIMPFV2BbrI5qtnpTtzErCKewoM8aw==",
       "dev": true,
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
-      "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.32.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
@@ -816,96 +804,96 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.6.0.tgz",
-      "integrity": "sha512-azs3aCIFrr3qkA/6lNIAYJ+wgDQ6cFoyeHVcZXP0E96AiOeVqtAu5ZXSA63Cw/63pSw0Itmx6CHUGu41enc0TQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.8.0.tgz",
+      "integrity": "sha512-ffP6AVHyISqK1kiUY1MoVKt43Wp3FJXI8NOePqxBrAU7bRDJ13276VbSl4ugCZbZLTPrPhhSmvQh1WqlfUgcAg==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/core": "1.6.0"
+        "@opentelemetry/core": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.6.0.tgz",
-      "integrity": "sha512-QgvWVgRS+APP7aHGPHgKo7HXJg2BbwW394kDNW1HeIxrywliUdAk8h5SJ/VGehy/dTzCFwbDd5Y3TMQRUNCHDg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.8.0.tgz",
+      "integrity": "sha512-v6GA38k2cqeGAh3368prLW5MsuG2/KxpfWI/PxTPjCa9tThDPq0cvhKpk7cEma3y+F6rieMhwmzZhKQL5QVBzQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/core": "1.6.0"
+        "@opentelemetry/core": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.6.0.tgz",
-      "integrity": "sha512-07GlHuq72r2rnJugYVdGumviQvfrl8kEPidkZSVoseLVfIjV7nzxxt5/vqs9pK7JItWOrvjRdr/jTBVayFBr/w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
+      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.6.0.tgz",
-      "integrity": "sha512-yx/uuzHdT0QNRSEbCgXHc0GONk90uvaFcPGaNowIFSl85rTp4or4uIIMkG7R8ckj8xWjDSjsaztH6yQxoZrl5g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
+      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/resources": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.6.0.tgz",
-      "integrity": "sha512-rE6hL68QuSS2vDXZBhNiAkeN7kzDGrrJdzGeeyxQahmugnId5jmu1OYERIeULiKHQVkBjvycfmwPYsCL+3PsHQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.8.0.tgz",
+      "integrity": "sha512-6FqhJEgW9Nke5SO4Ul9+5EWOfms/JeLg5LRqILMPMK4UMBWcOtk7jldvGGyfVpraJ16/WPo/R5NSnMwlupN5zQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.6.0",
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/propagator-b3": "1.6.0",
-        "@opentelemetry/propagator-jaeger": "1.6.0",
-        "@opentelemetry/sdk-trace-base": "1.6.0",
+        "@opentelemetry/context-async-hooks": "1.8.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/propagator-b3": "1.8.0",
+        "@opentelemetry/propagator-jaeger": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
       "engines": {
         "node": ">=14"
       }
@@ -6004,102 +5992,93 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
-    },
-    "@opentelemetry/api-metrics": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
-      "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
-      "requires": {
-        "@opentelemetry/api": "^1.0.0"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.6.0.tgz",
-      "integrity": "sha512-7xpyfHfuHnuCm5eAk4j4MIZjRM/hsiLlKEFIwI8SXNlbxqmb/JRrntOjN/AT+KeihkMw+xAx+0lsYPUANCSaQw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
+      "integrity": "sha512-ueLmocbWDi1aoU4IPdOQyt4qz/Dx+NYyU4qoa3d683usbnkDLUXYXJFfKIMPFV2BbrI5qtnpTtzErCKewoM8aw==",
       "dev": true,
       "requires": {}
     },
     "@opentelemetry/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
       "dev": true,
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
-      "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.32.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.6.0.tgz",
-      "integrity": "sha512-azs3aCIFrr3qkA/6lNIAYJ+wgDQ6cFoyeHVcZXP0E96AiOeVqtAu5ZXSA63Cw/63pSw0Itmx6CHUGu41enc0TQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.8.0.tgz",
+      "integrity": "sha512-ffP6AVHyISqK1kiUY1MoVKt43Wp3FJXI8NOePqxBrAU7bRDJ13276VbSl4ugCZbZLTPrPhhSmvQh1WqlfUgcAg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/core": "1.6.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.6.0.tgz",
-      "integrity": "sha512-QgvWVgRS+APP7aHGPHgKo7HXJg2BbwW394kDNW1HeIxrywliUdAk8h5SJ/VGehy/dTzCFwbDd5Y3TMQRUNCHDg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.8.0.tgz",
+      "integrity": "sha512-v6GA38k2cqeGAh3368prLW5MsuG2/KxpfWI/PxTPjCa9tThDPq0cvhKpk7cEma3y+F6rieMhwmzZhKQL5QVBzQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/core": "1.6.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.6.0.tgz",
-      "integrity": "sha512-07GlHuq72r2rnJugYVdGumviQvfrl8kEPidkZSVoseLVfIjV7nzxxt5/vqs9pK7JItWOrvjRdr/jTBVayFBr/w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
+      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.6.0.tgz",
-      "integrity": "sha512-yx/uuzHdT0QNRSEbCgXHc0GONk90uvaFcPGaNowIFSl85rTp4or4uIIMkG7R8ckj8xWjDSjsaztH6yQxoZrl5g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
+      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/resources": "1.6.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.6.0.tgz",
-      "integrity": "sha512-rE6hL68QuSS2vDXZBhNiAkeN7kzDGrrJdzGeeyxQahmugnId5jmu1OYERIeULiKHQVkBjvycfmwPYsCL+3PsHQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.8.0.tgz",
+      "integrity": "sha512-6FqhJEgW9Nke5SO4Ul9+5EWOfms/JeLg5LRqILMPMK4UMBWcOtk7jldvGGyfVpraJ16/WPo/R5NSnMwlupN5zQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.6.0",
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/propagator-b3": "1.6.0",
-        "@opentelemetry/propagator-jaeger": "1.6.0",
-        "@opentelemetry/sdk-trace-base": "1.6.0",
+        "@opentelemetry/context-async-hooks": "1.8.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/propagator-b3": "1.8.0",
+        "@opentelemetry/propagator-jaeger": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "semver": "^7.3.5"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jenniferplusplus/opentelemetry-instrumentation-bullmq",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jenniferplusplus/opentelemetry-instrumentation-bullmq",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -3352,9 +3352,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -7923,9 +7923,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "dev": true
     },
     "just-extend": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "@opentelemetry/api": "^1.1.0",
     "@opentelemetry/instrumentation": "^0.32.0",
     "@opentelemetry/semantic-conventions": "^1.6.0",
-    "bullmq": "2.*",
     "flat": "^5.0.2"
+  },
+  "peerDependencies": {
+    "bullmq": "^1.90.1 || ^2 || ^3"
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^1.6.0",
@@ -41,6 +43,7 @@
     "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
     "@typescript-eslint/parser": "^5.35.1",
+    "bullmq": "^3.5.1",
     "eslint": "^8.23.0",
     "ioredis-mock": "^8.2.2",
     "mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -24,18 +24,18 @@
   "author": "\"Jennifer Moore\" <contact@jenniferplusplus.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentelemetry/api": "^1.1.0",
-    "@opentelemetry/instrumentation": "^0.32.0",
-    "@opentelemetry/semantic-conventions": "^1.6.0",
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/instrumentation": "^0.34.0",
+    "@opentelemetry/semantic-conventions": "^1.8.0",
     "flat": "^5.0.2"
   },
   "peerDependencies": {
     "bullmq": "^1.90.1 || ^2 || ^3"
   },
   "devDependencies": {
-    "@opentelemetry/context-async-hooks": "^1.6.0",
-    "@opentelemetry/sdk-trace-base": "^1.6.0",
-    "@opentelemetry/sdk-trace-node": "^1.6.0",
+    "@opentelemetry/context-async-hooks": "^1.8.0",
+    "@opentelemetry/sdk-trace-base": "^1.8.0",
+    "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/flat": "^5.0.2",
     "@types/ioredis": "^4.28.10",
     "@types/mocha": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "compile:watch": "tsc -w",
     "lint": "eslint src/ test/ --ext .ts",
     "lint:fix": "eslint src/ test/ --ext .ts --fix",
+    "prepare": "npm run compile",
     "test": "mocha --require ts-node/register --exit --timeout 10000 test/**/*.test.ts"
   },
   "keywords": [

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -48,6 +48,8 @@ export class Instrumentation extends InstrumentationBase {
 
   private _onPatchMain() {
     return (moduleExports: typeof bullmq) => {
+      this._diag.debug('patching');
+
       // As Spans
       this._wrap(moduleExports.Queue.prototype, 'add', this._patchQueueAdd());
       this._wrap(moduleExports.Queue.prototype, 'addBulk', this._patchQueueAddBulk());
@@ -70,6 +72,8 @@ export class Instrumentation extends InstrumentationBase {
 
   private _onUnPatchMain() {
     return (moduleExports: typeof bullmq) => {
+      this._diag.debug('un-patching');
+
       this._unwrap(moduleExports.Queue.prototype, 'add');
       this._unwrap(moduleExports.Queue.prototype, 'addBulk');
       this._unwrap(moduleExports.FlowProducer.prototype, 'add')

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -40,7 +40,7 @@ export class Instrumentation extends InstrumentationBase {
   protected init() {
     return new InstrumentationNodeModuleDefinition<typeof bullmq>(
       'bullmq',
-      ['1.*', '2.*'],
+      ['1.*', '2.*', '3.*'],
       this._onPatchMain(),
       this._onUnPatchMain(),
     );
@@ -285,7 +285,8 @@ export class Instrumentation extends InstrumentationBase {
             [BullMQAttributes.WORKER_LOCK_RENEW]: this.opts?.lockRenewTime ?? 'default',
             [BullMQAttributes.WORKER_RATE_LIMIT_MAX]: this.opts?.limiter?.max ?? 'none',
             [BullMQAttributes.WORKER_RATE_LIMIT_DURATION]: this.opts?.limiter?.duration ?? 'none',
-            [BullMQAttributes.WORKER_RATE_LIMIT_GROUP]: this.opts?.limiter?.groupKey ?? 'none',
+            // Limit by group keys was removed in bullmq 3.x
+            [BullMQAttributes.WORKER_RATE_LIMIT_GROUP]: (this.opts?.limiter as any)?.groupKey ?? 'none',
           },
           kind: SpanKind.INTERNAL
         });


### PR DESCRIPTION
This PR adds support for bullmq 3.x, while keeping support for 1.x and 2.x. It moves bullmq to a peer dependency, so the consumer doesn't end up with multiple versions. It also allows installing directly from git by adding a prepare script. Finally, it adds debug logging for patch and unpatch, to help with debugging.