### PR TITLE
Update Nodejs targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         bullmq-version: [1.90.x, 2.x, 3.x]
     services:
       redis:
@@ -42,11 +42,11 @@ jobs:
         with:
           file-url: https://unpkg.com/@jenniferplusplus/opentelemetry-instrumentation-bullmq@latest/package.json
           static-checking: localIsNew
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         if: steps.version.outputs.changed == 'true'
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install
         if: steps.version.outputs.changed == 'true'
         run: npm ci


### PR DESCRIPTION
Add v20.x and drop v14.x, to reflect current Node.js support schedule