### PR TITLE
feat(job): expose priority metric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jenniferplusplus/opentelemetry-instrumentation-bullmq",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jenniferplusplus/opentelemetry-instrumentation-bullmq",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38,7 +38,7 @@
         "typescript": "^4.8.2"
       },
       "peerDependencies": {
-        "bullmq": "^2 || ^3 || ^4"
+        "bullmq": "^2 || ^3 || ^4 || ^5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -10,6 +10,7 @@ export const BullMQAttributes = {
   JOB_FAILED_REASON: `${job}.failedReason`,
   JOB_FINISHED_TIMESTAMP: `${job}.finishedOn`,
   JOB_PROCESSED_TIMESTAMP: `${job}.processedOn`,
+  JOB_PRIORITY: `${job}.priority`,
   JOB_NAME: `${job}.name`,
   JOB_OPTS: `${job}.opts`,
   JOB_REPEAT_KEY: `${job}.repeatJobKey`,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -140,7 +140,7 @@ export class Instrumentation extends InstrumentationBase {
 
     return function add(original) {
       return async function patch(this: Queue, ...args: any): Promise<Job> {
-        const [name] = [...args];
+        const [name, data, opts = {}] = [...args];
 
         const spanName = `${this.name}.${name} ${action}`;
         const span = tracer.startSpan(spanName, {
@@ -148,6 +148,7 @@ export class Instrumentation extends InstrumentationBase {
             [SemanticAttributes.MESSAGING_SYSTEM]: BullMQAttributes.MESSAGING_SYSTEM,
             [SemanticAttributes.MESSAGING_DESTINATION]: this.name,
             [BullMQAttributes.JOB_NAME]: name,
+            [BullMQAttributes.JOB_PRIORITY]: opts.priority || 0,
           },
           kind: SpanKind.INTERNAL
         });
@@ -244,6 +245,7 @@ export class Instrumentation extends InstrumentationBase {
             [BullMQAttributes.JOB_NAME]: job.name,
             [BullMQAttributes.JOB_ATTEMPTS]: job.attemptsMade,
             [BullMQAttributes.JOB_TIMESTAMP]: job.timestamp,
+            [BullMQAttributes.JOB_PRIORITY]: job.priority,
             [BullMQAttributes.JOB_DELAY]: job.delay,
             ...Instrumentation.attrMap(BullMQAttributes.JOB_OPTS, job.opts),
             [BullMQAttributes.QUEUE_NAME]: job.queueName,


### PR DESCRIPTION
while adding a job, we can pass a priority value that can be exposed to know how many jobs are being added in an specific priority