### PR TITLE
Test against node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 22.x]
         bullmq-version: [2.x, 3.x, 4.x, latest]
     services:
       redis:


### PR DESCRIPTION
Node 22 is now a current release and support for v21 ended recently.